### PR TITLE
chore: Generic placeholder relation query

### DIFF
--- a/djangocms_haystack/base.py
+++ b/djangocms_haystack/base.py
@@ -90,9 +90,10 @@ class DjangoCMSSearchIndexBase(indexes.SearchIndex):
     def get_placeholders(
         self, instance: models.Model, *args: list, **kwargs: dict
     ) -> models.QuerySet[Placeholder]:
-        if instance.placeholders:
-            return instance.placeholders.filter(*args, **kwargs)
-        return []
+        content_type = ContentType.objects.get_for_model(instance)
+        return Placeholder.objects.filter(
+                object_id=instance.pk, content_type=content_type
+            )
 
     def get_search_data(
         self, instance: models.Model, language: str, request: WSGIRequest

--- a/djangocms_haystack/search_indexes.py
+++ b/djangocms_haystack/search_indexes.py
@@ -21,9 +21,8 @@ class PageContentIndex(DjangoCMSSearchIndexBase, indexes.Indexable):
     def get_index_queryset(self, language):
         return PageContent.objects.filter(
             Q(redirect__exact="") | Q(redirect__isnull=True),
-            versions__state="published",
             language=language,
-        ).distinct()
+        )
 
     def should_update(self, instance, **kwargs):
         # Instantly update the index on pagecontent changes


### PR DESCRIPTION
@filipweidemann I did not test this, but this is how you should get all placeholders for a django CMS 4 model with a `PlaceholderRelationField`.

Also, I have removed the implicit reference to djangocms-versioning which - I believe is not necessary.